### PR TITLE
Fix race condition when table is started

### DIFF
--- a/data/gnu/ModuleGnu.cpp
+++ b/data/gnu/ModuleGnu.cpp
@@ -69,7 +69,7 @@ public:
 		  m_iMultiplier{}
   {
     char name[32];
-    //this->clear();
+    this->clear();
     Loader * loader = Loader::getInstance();
     m_sigBump = loader->getSignal("bump");
     int i = 0;


### PR DESCRIPTION
onTick() segfaults when m_iMultiplier is not initilized.

Signed-off-by: Frank Kunz <mailinglists@kunz-im-inter.net>